### PR TITLE
Adds slack badges to documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+- Slack badge in documentation
 - Add default lifecycle for targetgroups
 - Add default monitoring capabilities for ECS Services (default enabled)
 - Add Health Check Grace Period for services that need more time to start
@@ -16,4 +17,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Refactor outputs to support terraform 0.11
 - Add support to mount volumes
 
-[Unreleased]: https://github.com/philips-software/terraform-aws-ecs-service/compare/1.4.0...HEAD
+[Unreleased]: https://github.com/philips-software/terraform-aws-ecs-service/compare/1.0.0...HEAD

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,13 +6,13 @@ We'd love for you to contribute to our source code and to make the Forest even b
  - [Issues and Bugs](#issue)
  - [Feature Requests](#feature)
  - [Submission Guidelines](#submit)
- - [Coding Rules](#rules)
- - [Commit Message Guidelines](#commit)
  - [Further Info](#info)
 
 ## <a name="question"></a> Got a Question or Problem?
 
 If you have questions about how to use the Forest, please direct these to the [Slack group / philips-software][slack].
+
+[![Slack](https://philips-software-slackin.now.sh/badge.svg)](https://philips-software-slackin.now.sh)
 
 ## <a name="issue"></a> Found an Issue?
 
@@ -124,6 +124,14 @@ from the main (upstream) repository:
     ```shell
     git pull --ff upstream master
     ```
+
+## <a name="info"></a> Info
+
+For more info, please reach out to the team on [Slack group / philips-software][slack] in the #forest channel.
+
+Use the badge to sign-up.
+
+[![Slack](https://philips-software-slackin.now.sh/badge.svg)](https://philips-software-slackin.now.sh)
 
 [contribute]: CONTRIBUTING.md
 [github]: https://github.com/philips-software/terraform-aws-ecs-service/issues 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-The MIT License (MIT) Copyright © [2018] Koninklijke Philips N.V, https://www.philips.com
+The MIT License (MIT) Copyright © 2018 Koninklijke Philips N.V, https://www.philips.com
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ module "service" {
 | enable_monitoring | If true monitoring alerts will be created if needed. | string | `true` | no |
 | monitoring_sns_topic_arn | ARN for the SNS topic to send alerts to. This is required when monitoring is enabled (by default) | string | `` | no |
 | ecs_cluster_name | The name of the ECS cluster where this service will be launched. This is required when monitoring is enabled (by default) | string | `` | no |
+
 ## Outputs
 
 | Name | Description |
@@ -182,3 +183,21 @@ module "service" {
 | alb_dns_name | DNS address of the load balancer, if created. |
 | alb_route53_dns_name | Route 53 DNS name, if created. |
 | aws_alb_target_group_arn | ARN of the loadbalancer target group. |
+
+## Philips Forest
+
+This module is part of the Philips Forest.
+
+```
+                                                     ___                   _
+                                                    / __\__  _ __ ___  ___| |_
+                                                   / _\/ _ \| '__/ _ \/ __| __|
+                                                  / / | (_) | | |  __/\__ \ |_
+                                                  \/   \___/|_|  \___||___/\__|  
+
+                                                                 Infrastructure
+```
+
+Talk to the forestkeepers in the `forest`-channel on Slack.
+
+[![Slack](https://philips-software-slackin.now.sh/badge.svg)](https://philips-software-slackin.now.sh)


### PR DESCRIPTION
Add Slack Badge to enable faster communication with developers.

Keep documentation in line with: https://github.com/philips-software/terraform-aws-vpc/pull/1