### PR TITLE
Support for load balancer of type network

### DIFF
--- a/monitoring.tf
+++ b/monitoring.tf
@@ -185,7 +185,7 @@ resource "aws_cloudwatch_metric_alarm" "alb_healthy_hostcount_high" {
   insufficient_data_actions = ["${var.monitoring_sns_topic_arn}"]
 
   dimensions {
-    LoadBalancer = "${aws_alb.alb.arn_suffix}"
+    LoadBalancer = "${local.alb_arn_suffix}"
     TargetGroup  = "${aws_alb_target_group.target_group.arn_suffix}"
   }
 
@@ -215,7 +215,7 @@ resource "aws_cloudwatch_metric_alarm" "alb_healthy_hostcount_low" {
   insufficient_data_actions = ["${var.monitoring_sns_topic_arn}"]
 
   dimensions {
-    LoadBalancer = "${aws_alb.alb.arn_suffix}"
+    LoadBalancer = "${local.alb_arn_suffix}"
     TargetGroup  = "${aws_alb_target_group.target_group.arn_suffix}"
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -84,6 +84,11 @@ variable "alb_port" {
   default     = 443
 }
 
+variable "alb_load_balancer_type" {
+  description = "Load balancer type"
+  default     = "application"
+}
+
 variable "alb_certificate_arn" {
   description = "The AWS certificate ARN, required for an ALB via HTTPS. The certificate should be available in the same zone."
   type        = "string"


### PR DESCRIPTION
@npalm Let's check this one next week together.
Mainly, this change will allow to create use load balancers of type "network". By default, "application" will be used as it is currently doing.